### PR TITLE
Auto-adjust for daylight savings

### DIFF
--- a/lambda_functions/manage_ec2/serverless.yml
+++ b/lambda_functions/manage_ec2/serverless.yml
@@ -66,6 +66,8 @@ functions:
   EC2Scheduler:
     handler: handler.handler
     events:
-      - schedule: cron(3 21 ? * SUN-THU *)  # Run at 7:03am (Australia/Sydney - GMT+10) every Monday through Friday
-      - schedule: cron(3 09 ? * MON-FRI *)  # Run at 7:03pm (Australia/Sydney - GMT+10) every Monday through Friday
+      - schedule: cron(3 21 ? * SUN-THU *)  # Run at 7:03am AEST (GMT+10) every Monday through Friday
+      - schedule: cron(3 09 ? * MON-FRI *)  # Run at 7:03pm AEST (GMT+10) every Monday through Friday
+      - schedule: cron(3 20 ? * SUN-THU *)  # Also run an hour earlier (7:03am/pm AEDT, GMT+11)
+      - schedule: cron(3 08 ? * MON-FRI *)  #
 # - schedule: cron(3 0/1 ? * MON-FRI *)   # Run at every 3 minutes of every hour Monday through Friday


### PR DESCRIPTION
This manage-ec2 application involves an event handler that finds tagged EC2 instances, checks the local time, and tries to ensure those instances are either all started or all stopped. (The default environment variables specify the tag "stopAtNight" and 7am/7pm in Sydney.) 

However this lambda was only set to trigger at 08:03 & 20:03 AEDT weekdays, specified in UTC. 

To enable the specified behaviour to automatically transition between daylight savings time, this change is to trigger at 7:03 _both_ AEST & AEDT.

This change does double the total number of calls, and could be annoying for someone occasionally needing to manually start an instance again _twice_ in a summer evening or a winter morning. (If this were a concern then a possible alternative approach might be if the lambda only checked that the local time upon triggering was within a ~20min tolerance window of the switching time, and did nothing otherwise.)